### PR TITLE
Fix CapacidadSerializer para exportar Subclases

### DIFF
--- a/app/serializers/capacidad_serializer.rb
+++ b/app/serializers/capacidad_serializer.rb
@@ -1,5 +1,14 @@
 class CapacidadSerializer < ActiveModel::Serializer
+  attributes :subclases
+
   has_one  :clase, serializer: ClaseDeCapacidadSerializer
-  # FIXME Devolver las subclases como lista de códigos
-  has_many :subclases, serializer: SubclaseDeCapacidadSerializer
+
+  # Devolver la lista de códigos de subclases en su propia columna.
+  def subclases
+    resultado = []
+    object.subclases.each do |subclase|
+      resultado << subclase.codigo
+    end
+    resultado.join(' ')
+  end
 end

--- a/test/factories/capacidades.rb
+++ b/test/factories/capacidades.rb
@@ -6,9 +6,13 @@ FactoryGirl.define do
 
     transient { con_subclases 0 }
 
+    trait :con_clase do
+      association :clase, factory: :clase_de_capacidad
+    end
+
     after(:create) do |capacidad, params|
       params.con_subclases.times do
-        capacidad.subclases << build(:subclase_de_capacidad)
+        capacidad.subclases << build(:subclase_de_capacidad, :completa)
       end
     end
   end

--- a/test/factories/subclases_de_capacidad.rb
+++ b/test/factories/subclases_de_capacidad.rb
@@ -3,5 +3,9 @@
 FactoryGirl.define do
   factory :subclase_de_capacidad do
     codigo { generate :cadena_unica }
+
+    trait :completa do
+      descripcion { generate :cadena_unica }
+    end
   end
 end

--- a/test/models/serializers/capacidad_serializer_test.rb
+++ b/test/models/serializers/capacidad_serializer_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class CapacidadSerializerTest < ActiveSupport::TestCase
+  subject { CapacidadSerializer.new(capacidad) }
+  let(:capacidad) { create :capacidad, :con_clase, con_subclases: 2 }
+
+  it 'al serializar devuelve los códigos de clase y subclases por separado' do
+    codigos_subclases = capacidad.subclases.collect(&:codigo).join(' ')
+
+    _(subject.serializable_hash).must_equal({
+      clase: capacidad.clase.codigo,
+      subclases: codigos_subclases
+    })
+  end
+end


### PR DESCRIPTION
Ahora los export en CSV separan las Subclases de Capacidad en su propia columna.